### PR TITLE
Fix definitions for vim filetype

### DIFF
--- a/plugin/definitive.vim
+++ b/plugin/definitive.vim
@@ -12,7 +12,7 @@ let s:definitive_definitions = {
       \ 'ruby': '\<\(\(def\|class\|module\)\s\+\(self\.\)\=%1\>\|%1\s*=\)',
       \ 'scala': '\<\(val\|var\|def\|class\|trait\|object\)\s\+%1\>',
       \ 'typescript': '\<\(\(const\|let\|var\)\s\+%1\>\|\(function\s\+\)\=%1\s*(.*)\s*{\|class\s\+%1\s*{\)',
-      \ 'vim': '\<\(let\|function[!]\)\s\+\([agls]:\)\=%1\>'
+      \ 'vim': '\<\(let\s\+\([agls]:\)\?%1\s*=\|function!\?\s\+\([agls]:\)\?%1\s*(\)'
       \}
 let s:definitive_root_markers = {
       \ 'all': [ '.git', '.gitignore', '.hg', '.hgignore', 'Makefile' ],
@@ -65,7 +65,7 @@ function! definitive#FindDefinition(...)
     set grepformat=%f:%l:%m
   endif
 
-  exec "silent grep! " . l:wanted_definition
+  exec "silent grep! " . escape(l:wanted_definition, '#')
 
   let &grepprg = l:grepprg_save
   let &grepformat = l:grepformat_save


### PR DESCRIPTION
Fixes two problems with `vim` files:

- Functions weren't detected because of the required `=`, so the patterns for variables and functions are separate now.
- Searching for a pattern containing `#` caused an error `E194: No alternate file name to substitute for '#'`, so this needs to be escaped.