### PR TITLE
Move cursor to start of matched identifier

### DIFF
--- a/plugin/definitive.vim
+++ b/plugin/definitive.vim
@@ -52,7 +52,9 @@ function! definitive#FindDefinition(...)
   let l:match_in_current_file = search(l:search_text, 'wcbs')
 
   if l:match_in_current_file
-    exec l:match_in_current_file
+    call cursor(l:match_in_current_file, 0)
+    let [_, col] = searchpos(l:wanted_definition, 'c', line('.'))
+    call cursor(0, col)
     return
   endif
 


### PR DESCRIPTION
Currently the plugin only jumps to the line of the matched definition,
but keeps the current cursor column. With this, it instead:

- First jumps to the line of the match (e.g. `def foo` in Ruby)
- Does another search for the identifier (`foo`) and jumps to the column