### PR TITLE
Also move cursor to match start in other files

### DIFF
--- a/plugin/definitive.vim
+++ b/plugin/definitive.vim
@@ -62,8 +62,8 @@ function! definitive#FindDefinition(...)
   exec 'cd ' . s:GetProjectRoot()
 
   if s:IsInGitRepo()
-    set grepprg=git\ grep\ -n\ --no-color\ --untracked
-    set grepformat=%f:%l:%m
+    set grepprg=git\ grep\ -n\ --no-color\ --untracked\ --column
+    set grepformat=%f:%l:%c:%m
   endif
 
   exec "silent grep! " . escape(l:wanted_definition, '#')


### PR DESCRIPTION
This extends https://github.com/misterbuckley/vim-definitive/pull/17 to also apply when the match is not in the current file.