### PR TITLE
Add CSS and SCSS definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Languages currently supported by default:
 - Rust
 - Swift
 - Haskell
+- CSS
+- SCSS
 
 `g:definitive_associated_filetypes` is used to tell vim-definitive to use a
 certain filetype's definition when searching from a different filetype. An

--- a/plugin/definitive.vim
+++ b/plugin/definitive.vim
@@ -25,6 +25,8 @@ let s:definitive_definitions = {
       \ 'rust': '\<\(fn\|struct\|enum\|trait\|type\|mod\)\s\+%1\>\|\<let\s\+\(mut\s\+\)?%1\s*[:=]',
       \ 'swift': '\<\(func\|class\|struct\|enum\|protocol\|typealias\|let\|var\)\s\+%1\>',
       \ 'haskell': '\<\(data\|newtype\|type\|class\)\s\+%1\>\|\<%1\s*::\|\<%1\s*=',
+      \ 'css': '\([.#]\)%1[^,{]*{',
+      \ 'scss': '\$%1\s*:\|@\(mixin\|function\)\s\+%1\>\|%\s*%1\s*{',
       \ 'vim': '\<\(let\s\+\([agls]:\)\?%1\s*=\|function!\?\s\+\([agls]:\)\?%1\s*(\)'
       \}
 let s:definitive_root_markers = {


### PR DESCRIPTION
## Summary
- support locating CSS classes and SCSS variables/mixins/functions
- document CSS and SCSS as supported languages

## Testing
- `vim -Nu NONE -c 'source plugin/definitive.vim | quit'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684980775cac8329b90a344ce94dc0a5